### PR TITLE
Changed NuGetDir for Xamarin.iOS to support Xamarin.Mac

### DIFF
--- a/grunt/Gruntfile.js
+++ b/grunt/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
       { "Name": "SocketIoClientDotNet.net40", "NuGetDir": "net40", "SourceDir": "" },
       { "Name": "SocketIoClientDotNet.net45", "NuGetDir": "net45", "SourceDir": "" },
       { "Name": "SocketIoClientDotNet.windowsphone8", "NuGetDir": "windowsphone8", "SourceDir": "" },
-      { "Name": "SocketIoClientDotNet.Xamarin-iOS", "NuGetDir": "xamarinios10", "SourceDir": "xamarinios10" },
+      { "Name": "SocketIoClientDotNet.Xamarin-iOS", "NuGetDir": "portable-Xamarin.iOS10+Xamarin.Mac20", "SourceDir": "xamarinios10" },
       { "Name": "SocketIoClientDotNet.Xamarin-MonoTouch", "NuGetDir": "monotouch10", "SourceDir": "monotouch10" },
       { "Name": "SocketIoClientDotNet.Xamarin-Android", "NuGetDir": "monoandroid10", "SourceDir": "", copyOnly: true },
       { "Name": "SocketIoClientDotNet.netcore45", "NuGetDir": "netcore45","SourceDir": "", copyOnly: true  },

--- a/grunt/templates/SocketIoClientDotNet.nuspec
+++ b/grunt/templates/SocketIoClientDotNet.nuspec
@@ -47,6 +47,11 @@
         <dependency id="Newtonsoft.Json" version="8.0.1" />
         <dependency id="EngineIoClientDotNet" version="0.9.22" />
       </group>
+      <group targetFramework="Xamarin.Mac20">
+        <dependency id="WebSocket4Net" version="0.14.1" />
+        <dependency id="Newtonsoft.Json" version="8.0.1" />
+        <dependency id="EngineIoClientDotNet" version="0.9.22" />
+      </group>
       <group targetFramework="monotouch10">
         <dependency id="WebSocket4Net" version="0.14.1" />
         <dependency id="Newtonsoft.Json" version="8.0.1" />


### PR DESCRIPTION
From what I can tell (and what I tested), the Xamarin.iOS version does not use any iOS specific features. Given that and since Xamarin.Mac is IL compatible with Xamarin.iOS, the current Xamarin.iOS dll can be put into a special NuGetDir that will open support for Xamarin.Mac as well as continue to support Xamarin.iOS.