### PR TITLE
Fix exception regarding modification after enumerator

### DIFF
--- a/Src/SocketIoClientDotNet.net45/Client/Manager.cs
+++ b/Src/SocketIoClientDotNet.net45/Client/Manager.cs
@@ -397,7 +397,9 @@ namespace Quobject.SocketIoClientDotNet.Client
         {
             foreach (var sub in Subs)
             {
-                sub.Destroy();
+                lock (Subs) {
+                    sub.Destroy();
+                }
             }
         }
 


### PR DESCRIPTION
Received exception due to modification of subs during enumeration. Added a lock guard. Tested working in Xamarin for Android.