### PR TITLE
Fix loss of sibling properties in JSON with binary data

### DIFF
--- a/Src/SocketIoClientDotNet.net45/Parser/Binary.cs
+++ b/Src/SocketIoClientDotNet.net45/Parser/Binary.cs
@@ -161,8 +161,7 @@ namespace Quobject.SocketIoClientDotNet.Parser
                             //newData[i] = (string) recValue;
                             newData.Add((string)recValue);
                         }
-
-                        if (recValue is byte[])
+                        else if (recValue is byte[])
                         {
                             newData.Add((byte[])recValue);
                         }
@@ -204,7 +203,11 @@ namespace Quobject.SocketIoClientDotNet.Parser
                 try
                 {
                     var recValue = _reconstructPacket(property.Value, buffers);
-                    if (recValue is byte[])
+                    if (recValue is string)
+                    {
+                        newData1[property.Name] = (string)recValue;
+                    }
+                    else if (recValue is byte[])
                     {
                         newData1[property.Name] = (byte[])recValue;
                     }


### PR DESCRIPTION
When receiving binary data I found that if other properties were being sent alongside the data they were lost. So:

```
{
    x: 3,
    y: 4,
   data: "_placeholder" (for binary data)
}

```
would bring in just the binary "data" and not the "x" or "y".

I spent some time trying to get the test suite running but had trouble as I was going to write a test for it...but I ended up just debugging and fixing it at runtime (*sheepish grin*).

The first chunk in the PR change is just a missing else statement when it's checking type. That's not completely related it just happens to be in the same area and a nit optimization.

The second chunk is where the "string" case was added in to fix the problem. Looks like maybe it was doing that at one point? Not sure. Anyway, that did the trick...
