### PR TITLE
* Fixed bug where callin Cleanup sometimes caused a crash due to modi…

### DIFF
--- a/Src/SocketIoClientDotNet.net45/SocketIoClientDotNet.net45.csproj
+++ b/Src/SocketIoClientDotNet.net45/SocketIoClientDotNet.net45.csproj
@@ -31,23 +31,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EngineIoClientDotNet, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\EngineIoClientDotNet.0.10.1-beta2\lib\net45\EngineIoClientDotNet.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\EngineIoClientDotNet.0.10.1-beta2\lib\net45\EngineIoClientDotNet.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SuperSocket.ClientEngine, Version=0.8.0.6, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\SuperSocket.ClientEngine.Core.0.8.0.6\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\SuperSocket.ClientEngine.Core.0.8.0.6\lib\net45\SuperSocket.ClientEngine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="WebSocket4Net, Version=0.15.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\WebSocket4Net.0.15.0-beta6\lib\net45\WebSocket4Net.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\WebSocket4Net.0.15.0-beta6\lib\net45\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Src/SocketIoClientDotNet.net45/packages.config
+++ b/Src/SocketIoClientDotNet.net45/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EngineIoClientDotNet" version="0.10.1-beta2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="SuperSocket.ClientEngine.Core" version="0.8.0.6" targetFramework="net45" />
   <package id="WebSocket4Net" version="0.15.0-beta6" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
When calling open in Socket.cs it caused a crash from time to time in Cleanup: 

<img width="493" alt="crash" src="https://cloud.githubusercontent.com/assets/5681202/25898837/f1c05c90-358d-11e7-9b90-26e32eda3697.png">

This occured since the Subs-queue was being modified while used in a enumerator. By using a threadsafe version (in .Net-portable), ConcurrentQueue, this issue is solved since ConcurrentQueue returns a copy of its contents when calling GetEnumerator, making it safe to use while other manipulate the original object.