### PR TITLE
Fix Manager leak while reconnecting.

### DIFF
--- a/Src/SocketIoClientDotNet.net45/Client/Manager_net35.cs
+++ b/Src/SocketIoClientDotNet.net45/Client/Manager_net35.cs
@@ -419,6 +419,7 @@ namespace Quobject.SocketIoClientDotNet.Client
                 {
                     sub.Destroy();
                 }
+                Subs.Clear();
             }
         }
 


### PR DESCRIPTION
    - Manager.Cleanup() does not cleanup the queue.
    - While reconnecting, not items are added to Manager.Subs, but never cleared
    - Now Manager.Cleanup() clears out Manager.Subs.