### PR TITLE
Bug Fixed. Now you can use correctly Emit, passing param, not only string !

### DIFF
--- a/Src/SocketIoClientDotNet.Tests.netstandard1.3/SocketIoClientDotNet.Tests.netstandard1.3.csproj
+++ b/Src/SocketIoClientDotNet.Tests.netstandard1.3/SocketIoClientDotNet.Tests.netstandard1.3.csproj
@@ -32,4 +32,8 @@
     <ProjectReference Include="..\SocketIoClientDotNet.netstandard1.3\SocketIoClientDotNet.netstandard1.3.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/Src/SocketIoClientDotNet.net45/Parser/Packet.cs
+++ b/Src/SocketIoClientDotNet.net45/Parser/Packet.cs
@@ -58,17 +58,15 @@ namespace Quobject.SocketIoClientDotNet.Parser
             var args = new List<object>();
             foreach (var o in jarray)
             {
-                if (o is JValue)
+                if (o is JValue jval)
                 {
-                    var jval = (JValue)o;
                     if (jval != null)
                     {
                         args.Add(jval.Value);
                     }
                 }
-                else if (o is JToken)
+                else if (o is JToken jtoken)
                 {
-                    var jtoken = (JToken)o;
                     if (jtoken != null)
                     {
                         args.Add(jtoken);
@@ -85,8 +83,15 @@ namespace Quobject.SocketIoClientDotNet.Parser
             var jsonArgs = new JArray();
             foreach (var o in _args)
             {
-                jsonArgs.Add(o);
+                if (!(o is string))
+                {
+                    var obj = JObject.FromObject(o);
+                    jsonArgs.Add(obj);
+                }
+                else
+                    jsonArgs.Add(o);
             }
+
             return jsonArgs;
         }
 
@@ -103,7 +108,5 @@ namespace Quobject.SocketIoClientDotNet.Parser
             }
             return na;
         }
-
-
     }
 }

--- a/Src/SocketIoClientDotNet.net45/Parser/Parser.cs
+++ b/Src/SocketIoClientDotNet.net45/Parser/Parser.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-
 namespace Quobject.SocketIoClientDotNet.Parser
 {
     public class Parser

--- a/Src/SocketIoClientDotNet.netstandard1.3/SocketIoClientDotNet.netstandard1.3.csproj
+++ b/Src/SocketIoClientDotNet.netstandard1.3/SocketIoClientDotNet.netstandard1.3.csproj
@@ -6,8 +6,9 @@
     <AssemblyName>SocketIoClientDotNet</AssemblyName>
     <AssemblyVersion>1.0.5.0</AssemblyVersion>
     <FileVersion>1.0.5.0</FileVersion>
-    <Version>1.0.5</Version>
-    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <Version>1.0.7</Version>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bug Fixed. Now you can use correctly Emit, passing params. 
var socket = IO.Socket("http://localhost:3000");

socket.On("connect", () =>
{
    _log.Write($"Connected !");

    var login = new { name = "juanlu", password = "123456" };
    socket.Emit("login", login);
});