### PR TITLE
Added EVENT_ENGINE which is fired when a new engine socket is created.

### DIFF
--- a/Src/SocketIoClientDotNet.net45/Client/Manager.cs
+++ b/Src/SocketIoClientDotNet.net45/Client/Manager.cs
@@ -18,6 +18,7 @@ namespace Quobject.SocketIoClientDotNet.Client
             CLOSED
         }
 
+        public static readonly string EVENT_ENGINE = "engine";
         public static readonly string EVENT_OPEN = "open";
         public static readonly string EVENT_CLOSE = "close";
         public static readonly string EVENT_PACKET = "packet";
@@ -200,6 +201,7 @@ namespace Quobject.SocketIoClientDotNet.Client
             log.Info(string.Format("opening {0}", Uri));
             EngineSocket = new Engine(Uri, Opts);
             Quobject.EngineIoClientDotNet.Client.Socket socket = EngineSocket;
+            Emit(EVENT_ENGINE, socket);
 
             ReadyState = ReadyStateEnum.OPENING;
             OpeningSockets.Add(Socket(Uri.PathAndQuery));


### PR DESCRIPTION
This is a small change since the engine is already accessible via `socket.Io().EngineSocket`. The key difference is that this new event exposes it *before* it's open allowing application code to use it to subscribe to events like `EVENT_TRANSPORT` which opens a lot of doors.

My particular use-case is a bit hacky but with this small change I'm able to get hold of the transport layer at application level and add support for the `Set-Cookie` header allowing us to deploy a SocketIO server behind an AWS load balancer with sticky sessions (based on cookies). GAME CHANGER!