### PR TITLE
fix for wrong namespace creation: if using uri with queryParams, quer…

### DIFF
--- a/Src/SocketIoClientDotNet.net45/Client/IO.cs
+++ b/Src/SocketIoClientDotNet.net45/Client/IO.cs
@@ -60,7 +60,9 @@ namespace Quobject.SocketIoClientDotNet.Client
                 }
                 io = Managers[id];
             }
-            return io.Socket(uri.PathAndQuery);
+
+           //fix: used to paste path and query to namespace. Namespace is only supposed to use path
+            return io.Socket(uri.AbsolutePath);
         }
 
 

--- a/Src/SocketIoClientDotNet.net45/Client/Manager.cs
+++ b/Src/SocketIoClientDotNet.net45/Client/Manager.cs
@@ -204,7 +204,7 @@ namespace Quobject.SocketIoClientDotNet.Client
             Emit(EVENT_ENGINE, socket);
 
             ReadyState = ReadyStateEnum.OPENING;
-            OpeningSockets.Add(Socket(Uri.PathAndQuery));
+            OpeningSockets.Add(Socket(Uri.AbsolutePath));
             SkipReconnect = false;
 
             var openSub = SocketIoClientDotNet.Client.On.Create(socket, Engine.EVENT_OPEN, new ListenerImpl(() =>


### PR DESCRIPTION
...yParams used to be included in namespace. Path should only be included in namespace.

- couldn't connect to a stream with uri containing queryParams. Used to put them in the namespace which caused problem if default namespace was used.
